### PR TITLE
Fix build (installation) on Archlinux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ LIBDIR ?= /usr/lib64
 else
 LIBDIR ?= /usr/lib
 endif
+SYSLIBDIR ?= /lib
 INCLUDEDIR ?= /usr/include
 
 export LIBDIR INCLUDEDIR

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -6,7 +6,7 @@
 # Maintainer: Olivier Medoc <o_medoc@yahoo.fr>
 pkgname=qubes-vm-utils
 pkgver=`cat version`
-pkgrel=2
+pkgrel=3
 epoch=
 pkgdesc="Common Linux files for Qubes VM."
 arch=("x86_64")
@@ -43,7 +43,7 @@ make all
 
 package() {
 
-make install DESTDIR=$pkgdir LIBDIR=/usr/lib SBINDIR=/usr/bin
+make install DESTDIR=$pkgdir LIBDIR=/usr/lib SYSLIBDIR=/usr/lib SBINDIR=/usr/bin
 
 }
 

--- a/udev/Makefile
+++ b/udev/Makefile
@@ -1,14 +1,14 @@
 all:
 
 install:
-	mkdir -p $(DESTDIR)/lib/udev/rules.d
-	cp udev-qubes-block.rules $(DESTDIR)/lib/udev/rules.d/99-qubes-block.rules
-	cp udev-qubes-usb.rules $(DESTDIR)/lib/udev/rules.d/99-qubes-usb.rules
-	cp udev-qubes-misc.rules $(DESTDIR)/lib/udev/rules.d/99-qubes-misc.rules
+	mkdir -p $(DESTDIR)$(SYSLIBDIR)/udev/rules.d
+	cp udev-qubes-block.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/99-qubes-block.rules
+	cp udev-qubes-usb.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/99-qubes-usb.rules
+	cp udev-qubes-misc.rules $(DESTDIR)$(SYSLIBDIR)/udev/rules.d/99-qubes-misc.rules
 
-	mkdir -p $(DESTDIR)/usr/lib/qubes
-	cp udev-block-add-change $(DESTDIR)/usr/lib/qubes/
-	cp udev-block-remove $(DESTDIR)/usr/lib/qubes/
-	cp udev-block-cleanup $(DESTDIR)/usr/lib/qubes/
-	cp udev-usb-add-change $(DESTDIR)/usr/lib/qubes/
-	cp udev-usb-remove $(DESTDIR)/usr/lib/qubes/
+	mkdir -p $(DESTDIR)$(LIBDIR)/qubes
+	cp udev-block-add-change $(DESTDIR)$(LIBDIR)/qubes/
+	cp udev-block-remove $(DESTDIR)$(LIBDIR)/qubes/
+	cp udev-block-cleanup $(DESTDIR)$(LIBDIR)/qubes/
+	cp udev-usb-add-change $(DESTDIR)$(LIBDIR)/qubes/
+	cp udev-usb-remove $(DESTDIR)$(LIBDIR)/qubes/


### PR DESCRIPTION
`/lib` is a symlink to `/usr/lib` on Arch, so `/lib/blah...` paths cause installation to error out.

Not sure that adding another build variable is the right way to fix this (or that I've done it the right way) but the alternative used by core-agent-linux, to add a bunch of calls to `sed -i`, seemed a bit worse.
